### PR TITLE
Rewriting dependencies file and making the code dry

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ This is a script to help you to update your helm dependencies in your helm chart
 
 Why I build this tool? We have a lot of helm charts and we want to update the dependencies in all of them.
 The resources from helm-charts will be deployed over argocd, so the helm chart will no be installed on the cluster itself.
-Because of that you cant use tools like [renovate](https://github.com/renovatebot/helm-charts) or [dependabot](https://github.com/dependabot) running in the cluster. Since recently you can use renovate to update helm-values and maybe you like to use this tool instead of this script.
+Because of that you cant use tools like [renovate](https://github.com/renovatebot/helm-charts) or [dependabot](https://github.com/dependabot) running in the cluster. 
+Since recently you can use renovate to update helm-values and maybe you like to use this tool instead of this script.
 
 You can use this tool in your CI/CD pipeline or locally. The whole description about the script can be found on TBD.
 
@@ -36,35 +37,38 @@ config:
 
 This will only print the changes to the console. You can run the script with:
 
-    ./check-helm-dep-updates.sh
+```shell
+./check-helm-dep-updates.sh
+```
 
 You will get an output like:
+```
+ ####################### Begin #######################
+ Name: External DNS
+ Version in Chart.yaml: 6.20.4
+ Latest Version in Repository: 6.21.0
+ There's a difference between the versions.
+ Differences:
+     _        __  __
+   _| |_   _ / _|/ _|  between values.yaml
+ / _' | | | | |_| |_       and latest_values.yaml
+| (_| | |_| |  _|  _|
+ \__,_|\__, |_| |_|   returned two differences
+        |___/
 
-    ####################### Begin #######################
-    Name: External DNS
-    Version in Chart.yaml: 6.20.4
-    Current Version: 6.21.0
-    There's a difference between the versions.
-    Differences:
-        _        __  __
-    _| |_   _ / _|/ _|  between old_values.yaml
-    / _' | | | | |_| |_       and new_values.yaml
-    | (_| | |_| |  _|  _|
-    \__,_|\__, |_| |_|   returned two differences
-            |___/
+ (root level)
+ + one map entry added:
+ ## @param ingressClassFilters Filter sources managed by external-dns via IngressClass (optional)
+ ##
+ ingressClassFilters: []
 
-    (root level)
-    + one map entry added:
-    ## @param ingressClassFilters Filter sources managed by external-dns via IngressClass (optional)
-    ##
-    ingressClassFilters: []
+ image.tag
+ ± value change
+     - 0.13.4-debian-11-r19
+     + 0.13.5-debian-11-r55
 
-    image.tag
-    ± value change
-        - 0.13.4-debian-11-r19
-        + 0.13.5-debian-11-r55
-
-    ####################### End #######################
+ ####################### End #######################
+```
 
 ## GitHub
 
@@ -89,7 +93,9 @@ Commit and push the changes to your repository. After that you can run the scrip
 
 Execute the script with:
 
-    ./check-helm-dep-updates.sh
+```shell
+./check-helm-dep-updates.sh
+```
 
 Check the changes on GitHub and if you are happy with them, you can merge the PR.
 
@@ -97,7 +103,9 @@ Check the changes on GitHub and if you are happy with them, you can merge the PR
 
 First you have to create a PAT token. You can find more information here on the official [documentation](https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops&tabs=preview-page). After you created the PAT token, you need to set the following variable:
 
-    AZURE_DEVOPS_EXT_PAT=<your-pat-token>
+```shell
+AZURE_DEVOPS_EXT_PAT=<your-pat-token>
+```
 
 Now edit the key `config` in `dependencies.yaml` file like:
 
@@ -116,7 +124,9 @@ config:
 
 Execute the script with:
 
-    ./check-helm-dep-updates.sh
+```shell
+./check-helm-dep-updates.sh
+```
 
 Check the changes on Azure DevOps and if you are happy with them, you can merge the PR.
 
@@ -142,7 +152,9 @@ config:
 
 Execute the script with:
 
-    ./check-helm-dep-updates.sh
+```shell
+./check-helm-dep-updates.sh
+```
 
 Check the changes on your Git Provider and if you are happy with them, you can merge the PR.
 

--- a/check-helm-dep-updates.sh
+++ b/check-helm-dep-updates.sh
@@ -1,47 +1,52 @@
 #!/bin/bash
 set -eo pipefail
 
+DEBUG=${DEBUG:-"n"}
+if [[ "$DEBUG" =~ ^([yY])+$ ]]; then
+  set -x
+fi
+
 DIRNAME="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 pushd $DIRNAME > /dev/null
 
 file="dependencies.yaml"
+dependencies=$(yq e . $file)
 
 function setEnvsWithConfigFromFile() {
-
     # Gets the settings and creates a string to define local variables
-    yq e '.config | to_entries | map(.key + "=" + .value) | join(" ")' $file
-
+    yq e '.config | to_entries | map(.key + "=" + .value) | join(" ")' <<< ${dependencies}
 }
 
 # -------- functions ------------ #
 
 function readDependenciesFromFile() {
-
     # Get the number of dependencies
-    count=$(yq e '.dependencies | length' $file)
+    count=$(yq e '.dependencies | length' <<< ${dependencies})
 }
 
-function checkHelmDependenciesAndUpdateWithOutPR() {
-
-    # Iterate over the list
+function checkHelmDependencies() {
     for ((i = 0; i < $count; i++)); do
+
+        dependencyPath=".dependencies[$(yq e ".dependencies[$i].arrayPosition // 0" <<< ${dependencies})]"
+        chartSourcePath=$(yq e ".dependencies[$i].sourcePath" <<< ${dependencies})
+
         # Name of the dependency like External DNS
-        name=$(yq e ".dependencies[$i].name" $file)
+        name=$(yq e ".dependencies[$i].name" <<< ${dependencies})
         # Path to the Chart.yaml file
-        chart_file=$(yq e ".dependencies[$i].source.file" $file)
+        chart_file=$chartSourcePath/Chart.yaml
         # Path to the version number in the Chart.yaml file like 6.20.0
-        version_path=$(yq e ".dependencies[$i].source.path" $file)
+        version_path="${dependencyPath}.version"
         # Repository name for the Artifact API
-        repo_name=$(yq e ".dependencies[$i].repository.name" $file)
+        repo_name=$(yq e ".dependencies[$i].repositoryName" <<< ${dependencies})
         # Repository url for the Artifact API
-        repo_url_path=$(yq e ".dependencies[$i].repository.path" $file)
+        repo_url_path="${dependencyPath}.repository"
 
         # Sanitize the repo name
         sanitized_name=$(echo $repo_name | cut -d'/' -f1)
 
         #Change directory to the chart file directory
-        cd $(dirname $chart_file) || exit
+        pushd $chartSourcePath > /dev/null
 
         # Read the version from the Chart.yaml file
         version=$(yq e "$version_path" "$(basename $chart_file)")
@@ -51,321 +56,125 @@ function checkHelmDependenciesAndUpdateWithOutPR() {
         helm repo add $sanitized_name $repo_url || true
         helm repo update 1 &>/dev/null || true
 
-        #Get the current version with the Artifact API
-        current_version=$(helm search repo $repo_name --output yaml | yq eval '.[0].version')
+        #Get the latest version with the Artifact API
+        latest_version=$(helm search repo $repo_name --output yaml | yq e '.[0].version')
 
         # Output
         echo "Name: $name"
         echo "Version in Chart.yaml: $version"
-        echo "Current Version: $current_version"
+        echo "Latest Version in Repository: $latest_version"
 
-        # If there's a difference between the versions
-        if [ "$version" != "$current_version" ]; then
-            if [ ! $(git branch --list update-helm-$sanitized_name-$current_version) ]; then
-                echo "There's a difference between the versions."
-
-                # Get values from the repo
-                values=$(helm show values $repo_name --version $version)
-                echo "$values" >values.yaml
-                current_values=$(helm show values $repo_name --version $current_version)
-                echo "$current_values" >current_values.yaml
-
-                diff_result=$(dyff between values.yaml current_values.yaml) || true
-                # Output differences
-                echo "$diff_result" >diff_result.txt
-                awk '{ printf "\t%s\n", $0 }' diff_result.txt >shift_diff_result.txt
-                shift_diff_result=$(cat shift_diff_result.txt)
-
-                # Delete the temporary files
-                rm values.yaml current_values.yaml diff_result.txt shift_diff_result.txt
-
-                # Replace the old version with the new version in the Chart.yaml file using sed
-                sed -i.bak "s/version: $version/version: $current_version/g" "$(basename $chart_file)" && rm "$(basename $chart_file).bak"
-
-                # Create a new branch for this change
-                git checkout -b update-helm-$sanitized_name-$current_version
-                # Add the changes to the staging area
-                git add "$(basename $chart_file)"
-
-                # Create a commit with a message indicating the changes
-                git commit -m "Update $name version from $version to $current_version"
-
-                # Push the new branch to GitHub
-                git push origin update-helm-$sanitized_name-$current_version
-
-                # Get back to the source branch
-                git checkout $BRANCH
-
-            else
-                echo "Branch already exists. Checking out to the existing branch." || true
-            fi
-
-        else
-            echo "There's no difference between the versions."
-        fi
+        diffBetweenVersions
 
         # Return to the original directory
-        cd - 1>/dev/null || exit
-
-        echo ""
+        popd > /dev/null
     done
-
-}
-function checkHelmDependenciesAndUpdateGitHub() {
-
-    # Iterate over the list
-    for ((i = 0; i < $count; i++)); do
-        # Name of the dependency like External DNS
-        name=$(yq e ".dependencies[$i].name" $file)
-        # Path to the Chart.yaml file
-        chart_file=$(yq e ".dependencies[$i].source.file" $file)
-        # Path to the version number in the Chart.yaml file like 6.20.0
-        version_path=$(yq e ".dependencies[$i].source.path" $file)
-        # Repository name for the Artifact API
-        repo_name=$(yq e ".dependencies[$i].repository.name" $file)
-        # Repository url for the Artifact API
-        repo_url_path=$(yq e ".dependencies[$i].repository.path" $file)
-
-        # Sanitize the repo name
-        sanitized_name=$(echo $repo_name | cut -d'/' -f1)
-
-        #Change directory to the chart file directory
-        cd $(dirname $chart_file) || exit
-
-        # Read the version from the Chart.yaml file
-        version=$(yq e "$version_path" "$(basename $chart_file)")
-        repo_url=$(yq e "$repo_url_path" "$(basename $chart_file)")
-
-        # Add the repo to helm
-        helm repo add $sanitized_name $repo_url || true
-        helm repo update 1 &>/dev/null || true
-
-        #Get the current version with the Artifact API
-        current_version=$(helm search repo $repo_name --output yaml | yq eval '.[0].version')
-
-        # Output
-        echo "Name: $name"
-        echo "Version in Chart.yaml: $version"
-        echo "Current Version: $current_version"
-
-        # If there's a difference between the versions
-        if [ "$version" != "$current_version" ]; then
-            if [ ! $(git branch --list update-helm-$sanitized_name-$current_version) ]; then
-                echo "There's a difference between the versions."
-
-                # Get values from the repo
-                values=$(helm show values $repo_name --version $version)
-                echo "$values" >values.yaml
-                current_values=$(helm show values $repo_name --version $current_version)
-                echo "$current_values" >current_values.yaml
-
-                diff_result=$(dyff between values.yaml current_values.yaml) || true
-                # Output differences
-                echo "$diff_result" >diff_result.txt
-                awk '{ printf "\t%s\n", $0 }' diff_result.txt >shift_diff_result.txt
-                shift_diff_result=$(cat shift_diff_result.txt)
-
-                # Delete the temporary files
-                rm values.yaml current_values.yaml diff_result.txt shift_diff_result.txt
-
-                # Replace the old version with the new version in the Chart.yaml file using sed
-                sed -i.bak "s/version: $version/version: $current_version/g" "$(basename $chart_file)" && rm "$(basename $chart_file).bak"
-
-                # Create a new branch for this change
-                git checkout -b update-helm-$sanitized_name-$current_version
-                # Add the changes to the staging area
-                git add "$(basename $chart_file)"
-
-                # Create a commit with a message indicating the changes
-                git commit -m "Update $name version from $version to $current_version"
-
-                # Push the new branch to GitHub
-                git push origin update-helm-$sanitized_name-$current_version
-
-                # Create a GitHub Pull Request
-                gh pr create --title "Update $name version from $version to $current_version" --body "$shift_diff_result" --base main --head update-helm-$sanitized_name-$current_version || true
-
-                # Get back to the source branch
-                git checkout $BRANCH
-
-            else
-                echo "Branch already exists. Checking out to the existing branch." || true
-            fi
-
-        else
-            echo "There's no difference between the versions."
-        fi
-
-        # Return to the original directory
-        cd - 1>/dev/null || exit
-
-        echo ""
-    done
-
-}
-function checkHelmDependenciesAndUpdateAzureDevOps() {
-
-    # Iterate over the list
-    for ((i = 0; i < $count; i++)); do
-        # Name of the dependency like External DNS
-        name=$(yq e ".dependencies[$i].name" $file)
-        # Path to the Chart.yaml file
-        chart_file=$(yq e ".dependencies[$i].source.file" $file)
-        # Path to the version number in the Chart.yaml file like 6.20.0
-        version_path=$(yq e ".dependencies[$i].source.path" $file)
-        # Repository name for the Artifact API
-        repo_name=$(yq e ".dependencies[$i].repository.name" $file)
-        # Repository url for the Artifact API
-        repo_url_path=$(yq e ".dependencies[$i].repository.path" $file)
-
-        # Sanitize the repo name
-        sanitized_name=$(echo $repo_name | cut -d'/' -f1)
-
-        #Change directory to the chart file directory
-        cd $(dirname $chart_file) || exit
-
-        # Read the version from the Chart.yaml file
-        version=$(yq e "$version_path" "$(basename $chart_file)")
-        repo_url=$(yq e "$repo_url_path" "$(basename $chart_file)")
-
-        # Add the repo to helm
-        helm repo add $sanitized_name $repo_url || true
-        helm repo update 1 &>/dev/null || true
-
-        #Get the current version with the Artifact API
-        current_version=$(helm search repo $repo_name --output yaml | yq eval '.[0].version')
-
-        # Output
-        echo "Name: $name"
-        echo "Version in Chart.yaml: $version"
-        echo "Current Version: $current_version"
-
-        # If there's a difference between the versions
-        if [ "$version" != "$current_version" ]; then
-            if [ ! $(git branch --list update-helm-$sanitized_name-$current_version) ]; then
-                echo "There's a difference between the versions."
-
-                # Get values from the repo
-                values=$(helm show values $repo_name --version $version)
-                echo "$values" >values.yaml
-                current_values=$(helm show values $repo_name --version $current_version)
-                echo "$current_values" >current_values.yaml
-
-                diff_result=$(dyff between values.yaml current_values.yaml) || true
-                # Output differences
-                echo "$diff_result" >diff_result.txt
-                awk '{ printf "\t%s\n", $0 }' diff_result.txt >shift_diff_result.txt
-                shift_diff_result=$(cat shift_diff_result.txt)
-
-                # If the diff output is too large for display, overwrite it with a message
-                if ((${#shift_diff_result} > 4000)); then
-                    shift_diff_result="The diff output is too large for display (>4000 characters). Please refer to ArtifactHub directly for a detailed comparison of changes between the $version and $current_version."
-                fi
-
-                # Delete the temporary files
-                rm values.yaml current_values.yaml diff_result.txt shift_diff_result.txt
-
-                # Replace the old version with the new version in the Chart.yaml file using sed
-                sed -i.bak "s/version: $version/version: $current_version/g" "$(basename $chart_file)" && rm "$(basename $chart_file).bak"
-
-                # Create a new branch for this change
-                git checkout -b update-helm-$sanitized_name-$current_version
-                # Add the changes to the staging area
-                git add "$(basename $chart_file)"
-
-                # Create a commit with a message indicating the changes
-                git commit -m "Update $name version from $version to $current_version"
-
-                # Push the new branch to GitHub
-                git push origin update-helm-$sanitized_name-$current_version
-
-                # Create a Azure DevOps Pull Request
-                az repos pr create --title "Update $name version from $version to $current_version" --description "$shift_diff_result" --target-branch $BRANCH --source-branch update-helm-$sanitized_name-$current_version 1>/dev/null || true
-
-                # Get back to the source branch
-                git checkout $BRANCH
-
-            else
-                echo "Branch already exists. Checking out to the existing branch." || true
-            fi
-
-        else
-            echo "There's no difference between the versions."
-        fi
-
-        # Return to the original directory
-        cd - 1>/dev/null || exit
-
-        echo ""
-    done
-
 }
 
-function checkHelmDependenciesAndUpdateDryRun() {
+function diffBetweenVersions() {
+    if [ "$version" != "$latest_version" ]; then
+        tplBranchName=update-helm-$sanitized_name-$latest_version
 
-    # Iterate over the list
-    for ((i = 0; i < $count; i++)); do
-
-        # Name of the dependency like External DNS
-        name=$(yq e ".dependencies[$i].name" $file)
-        # Path to the Chart.yaml file
-        chart_file=$(yq e ".dependencies[$i].source.file" $file)
-        # Path to the version number in the Chart.yaml file like 6.20.0
-        version_path=$(yq e ".dependencies[$i].source.path" $file)
-        # Repository name for the Artifact API
-        repo_name=$(yq e ".dependencies[$i].repository.name" $file)
-        # Repository url for the Artifact API
-        repo_url_path=$(yq e ".dependencies[$i].repository.path" $file)
-
-        # Sanitize the repo name
-        sanitized_name=$(echo $repo_name | cut -d'/' -f1)
-
-        #Change directory to the chart file directory
-        cd $(dirname $chart_file) || exit
-
-        # Read the version from the Chart.yaml file
-        version=$(yq e "$version_path" "$(basename $chart_file)")
-        repo_url=$(yq e "$repo_url_path" "$(basename $chart_file)")
-
-        # Add the repo to helm
-        helm repo add $sanitized_name $repo_url || true
-        helm repo update 1 &>/dev/null || true
-
-        #Get the current version with the Artifact API
-        current_version=$(helm search repo $repo_name --output yaml | yq eval '.[0].version')
-
-        # Output
-        echo "####################### Begin #######################"
-        echo "Name: $name"
-        echo "Version in Chart.yaml: $version"
-        echo "Current Version: $current_version"
-
-        # If there's a difference between the versions
-        if [ "$version" != "$current_version" ]; then
+        if [ ! $(git branch --list $tplBranchName) ]; then
             echo "There's a difference between the versions."
+            
+            tempDir=$(mktemp -d -p "${PWD}")
 
+            diffValuesFile="${tempDir}/diff_value.yaml"
+            diffLatestValuesFile="${tempDir}/diff_latest_value.yaml"
+            diffResultFile="${tempDir}/diff_result.txt"
+            shiftDiffResultFile="${tempDir}/shift_diff_result.txt"
+            
             # Get values from the repo
-            values=$(helm show values $repo_name --version $version)
-            echo "$values" >values.yaml
-            current_values=$(helm show values $repo_name --version $current_version)
-            echo "$current_values" >current_values.yaml
+            helm show values $repo_name --version $version >$diffValuesFile
+            helm show values $repo_name --version $latest_version >$diffLatestValuesFile
 
-            diff_result=$(dyff between values.yaml current_values.yaml) || true
-            echo "$diff_result"
+            dyff between $diffValuesFile $diffLatestValuesFile >$diffResultFile
 
-            # Delete the temporary files
-            rm values.yaml current_values.yaml
+            awk '{ printf "\t%s\n", $0 }' $diffResultFile >$shiftDiffResultFile
+            shift_diff_result=$(cat $shiftDiffResultFile)
+
+            # If the diff output is too large for display, overwrite it with a message
+            if ((${#shift_diff_result} > 4000)); then
+                echo "The diff output is too large for display (>4000 characters).
+                Please refer to ArtifactHub directly for a detailed comparison of 
+                changes between the $version and $latest_version." >$shiftDiffResultFile
+            fi
+
+            if [ "$DRY_RUN" == "true" ]; then
+                dryRun
+            elif [ "$WITHOUT_PR" == "true" ]; then
+                withOutPR
+            elif [ "$GITHUB" == "true" ]; then
+                gitHub
+            elif [ "$AZURE_DEVOPS" == "true" ]; then
+                azureDevOps
+            fi
+            
+            rm -rf $tempDir
+
         else
-            echo "There's no difference between the versions."
-        fi
+        echo "There's no difference between the versions."
+        fi    
+    fi
+}
 
-        # Return to the original directory
-        cd - 1>/dev/null || exit
+function updateVersionInChartFile() {
+    # Replace the old version with the new version in the Chart.yaml file using sed
+    yq e -i "$version_path = \"$latest_version\"" "$(basename $chart_file)"
+}
 
-        echo ""
-        echo "####################### End #######################"
-    done
+function createCommitAndPushBranch() {
+    # Create a new branch for this change
+    git checkout -b $tplBranchName
 
+    # Add the changes to the staging area
+    git add "$(basename $chart_file)"
+
+    # Create a commit with a message indicating the changes
+    git commit -m "Update $name version from $version to $latest_version"
+
+    # Push the new branch to GitHub
+    git push origin $tplBranchName
+}
+
+function withOutPR() {
+    updateVersionInChartFile
+    createCommitAndPushBranch
+}
+
+function gitHub() {
+    updateVersionInChartFile
+    createCommitAndPushBranch
+
+    gh pr create \
+    --title "Update $name version from $version to $latest_version" \
+    --body "$shift_diff_result" \
+    --base $BRANCH \
+    --head $tplBranchName || true
+
+    # Get back to the source branch
+    git checkout $BRANCH
+}
+
+function azureDevOps() {
+    updateVersionInChartFile
+    createCommitAndPushBranch
+
+    # Create a Azure DevOps Pull Request
+    az repos pr create \
+        --title "Update $name version from $version to $latest_version" \
+        --description "$shift_diff_result" \
+        --target-branch $BRANCH \
+        --source-branch $tplBranchName 1>/dev/null || true
+
+    # Get back to the source branch
+    git checkout $BRANCH
+
+}
+
+function dryRun() {
+    cat $diffResultFile
 }
 
 function errorEcho {
@@ -378,47 +187,36 @@ function infoEcho {
 }
 
 function errorUsage {
+cat <<-EOF
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+|                                 ERROR: ${1}                                 |
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+EOF
 
-    echo "+ - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - +
-|                                 ERROR: ${1}                                    |
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -  "
     usage
     exit 1
 }
 
 function usage() {
-    echo "
+cat <<-EOF
 
+please set all necessary propertis in $file file.
+--------------- necessary-keys: -------------------
 
-  "
-    echo ""
-    echo "please set all necessary propertis in ${dependenciesFile} file "
-    echo "--------------- necessary-Variables: -------------------"
-    echo "config:
+config:
   BRANCH: main
   DRY_RUN: true
   GITHUB: false
   AZURE_DEVOPS: false
-  WITHOUT_PR: false"
-    echo ""
+  WITHOUT_PR: false
+EOF
 }
 
 function start() {
     # Read the file
     readDependenciesFromFile
     # Check if the dependencies are up to date
-    if [ "$DRY_RUN" == "true" ]; then
-        checkHelmDependenciesAndUpdateDryRun
-    fi
-    if [ "$WITHOUT_PR" == "true" ]; then
-        checkHelmDependenciesAndUpdateWithOutPR
-    fi
-    if [ "$GITHUB" == "true" ]; then
-        checkHelmDependenciesAndUpdateGitHub
-    fi
-    if [ "$AZURE_DEVOPS" == "true" ]; then
-        checkHelmDependenciesAndUpdateAzureDevOps
-    fi
+    checkHelmDependencies
 }
 
 # -------- Check Prerequisites ------------ #

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -7,30 +7,18 @@ config:
 
 dependencies:
   - name: "External DNS"
-    source:
-      file: dns/external-dns/Chart.yaml
-      path: .dependencies[0].version
-    repository:
-      name: bitnami/external-dns
-      path: .dependencies[0].repository
+    arrayPosition: 0
+    repositoryName: bitnami/external-dns
+    sourcePath: dns/external-dns
   - name: "Kyverno"
-    source:
-      file: security/kyverno/Chart.yaml
-      path: .dependencies[0].version
-    repository:
-      name: kyverno/kyverno
-      path: .dependencies[0].repository
+    arrayPosition: 0
+    repositoryName: kyverno/kyverno
+    sourcePath: security/kyverno
   - name: "minIO Operator"
-    source:
-      file: storage/minio-operator/Chart.yaml
-      path: .dependencies[0].version
-    repository:
-      name: minio-operator/operator
-      path: .dependencies[0].repository
+    arrayPosition: 0
+    repositoryName: minio-operator/operator
+    sourcePath: storage/minio-operator
   - name: "minIO Tenant"
-    source:
-      file: storage/minio-tenant/Chart.yaml
-      path: .dependencies[0].version
-    repository:
-      name: minio-operator/tenant
-      path: .dependencies[0].repository
+    arrayPosition: 0
+    repositoryName: minio-operator/tenant
+    sourcePath: storage/minio-tenant


### PR DESCRIPTION
Major changes added.

1- Exclusion of repetition in the routines that made the diff between the versions. It was unified everything in a single function
2- Specific function to try to prepare the local commit and push the branch to the repository
3- Specific functions to handle only DryRun, Github PR and Azure DevOps cases.
4- Modified dependencies format, simplifying the definition of dependencies without the need to repeat the main key of the dependency in the list of dependencies in Chart.yaml.
5- Performance improvement regarding dependencies.yaml file reading. Now the file is read only once and its values are stored in memory to be used by all further calls to `yq`.
6- Updated routine to change Chart.yaml using `yq` and deprecating use of `sed.

One more contribution to improve code organization, mainly removing code repetition.

Anything you want to suggest better, you can speak.
Thanks @la-cc 