### PR TITLE
Update minIO Operator version from 5.0.1 to 5.0.7

### DIFF
--- a/storage/minio-operator/Chart.yaml
+++ b/storage/minio-operator/Chart.yaml
@@ -3,6 +3,6 @@ name: minio-operator
 version: 1.0.0
 description: This Chart deploys minio-operator.
 dependencies:
-- name: operator
-  version: 5.0.1
-  repository: https://operator.min.io/
+  - name: operator
+    version: 5.0.7
+    repository: https://operator.min.io/


### PR DESCRIPTION
	     _        __  __
	   _| |_   _ / _|/ _|  between /var/folders/38/7j5yy3mj45n46n9j_fk385g80000gn/T/tmp.rn3nieEg/diff_value.yaml
	 / _' | | | | |_| |_       and /var/folders/38/7j5yy3mj45n46n9j_fk385g80000gn/T/tmp.rn3nieEg/diff_latest_value.yaml
	| (_| | |_| |  _|  _|
	 \__,_|\__, |_| |_|   returned four differences
	        |___/
	
	operator
	  - one map entry removed:     + five map entries added:
	    initcontainers: []           runtimeClassName: ~
	                                 initContainers: []
	                                 env: []
	                                 volumes: []
	                                 volumeMounts: []
	
	operator.image.tag
	  ± value change
	    - v5.0.1
	    + v5.0.7
	
	console
	  - one map entry removed:     + three map entries added:
	    initcontainers: []           env: []
	                                 runtimeClassName: ~
	                                 initContainers: []
	
	console.image.tag
	  ± value change
	    - v5.0.1
	    + v5.0.7
	