### PR TITLE
Update External DNS version from 6.20.4 to 6.23.5

### DIFF
--- a/examples/dns/external-dns/Chart.yaml
+++ b/examples/dns/external-dns/Chart.yaml
@@ -4,5 +4,5 @@ version: 1.0.0
 description: This Chart deploys external-dns.
 dependencies:
   - name: external-dns
-    version: 6.20.4
+    version: 6.23.5
     repository: https://charts.bitnami.com/bitnami


### PR DESCRIPTION
	     _        __  __
	   _| |_   _ / _|/ _|  between /var/folders/38/7j5yy3mj45n46n9j_fk385g80000gn/T/tmp.UI0Ee12O/diff_value.yaml
	 / _' | | | | |_| |_       and /var/folders/38/7j5yy3mj45n46n9j_fk385g80000gn/T/tmp.UI0Ee12O/diff_latest_value.yaml
	| (_| | |_| |  _|  _|
	 \__,_|\__, |_| |_|   returned four differences
	        |___/
	
	(root level)
	+ two map entries added:
	  ## @param ingressClassFilters Filter sources managed by external-dns via IngressClass (optional)
	  ##
	  ingressClassFilters: []
	  ## @param managedRecordTypesFilters Filter record types managed by external-dns (optional)
	  ##
	  managedRecordTypesFilters: []
	  
	
	
	image.tag
	  ± value change
	    - 0.13.4-debian-11-r19
	    + 0.13.5-debian-11-r75
	
	rfc2136.tsigKeyname
	  ± value change
	    - externaldns-key
	    + rfc2136_tsig_secret
	
	service
	  + one map entry added:
	    ## @param service.externalName Service external name
	    ##
	    externalName:
	